### PR TITLE
intWord passing tests

### DIFF
--- a/spec/intWord_spec.js
+++ b/spec/intWord_spec.js
@@ -4,4 +4,8 @@ describe("CQL.intWord", function() {
   it("Converts 1000 to 1 thousand", function() {
     expect(CQL.intWord(1000)).toBe("1 thousand");
   });
+  it("Converts 100 to 1 hundred", function(){
+    expect(CQL.intWord(100)).toBe("1 hundred");
+  });
+
 });

--- a/spec/intWord_spec.js
+++ b/spec/intWord_spec.js
@@ -1,6 +1,7 @@
 var CQL = require("../index");
 
 describe("CQL.intWord", function() {
-  xit("Converts 1000 to 1 thousand", function() {
+  it("Converts 1000 to 1 thousand", function() {
+    expect(CQL.intWord(1000)).toBe("1 thousand");
   });
 });

--- a/src/intComma.js
+++ b/src/intComma.js
@@ -3,6 +3,8 @@ function intComma(value) {
   /*
    *  Converts an integer to a string with commas every 3 digits.
    */
+  /*jslint unparam: true*/
+  return "1";
 }
 
 module.exports = intComma;

--- a/src/intOrdinal.js
+++ b/src/intOrdinal.js
@@ -6,6 +6,8 @@ function intOrginal(value) {
    *  2 => 2nd
    *  3 => 3rd
    */
+  /*jslint unparam: true*/
+  return "1st";
 }
 
 module.exports = intOrginal;

--- a/src/intWord.js
+++ b/src/intWord.js
@@ -3,14 +3,15 @@ function intWord(value) {
   /*
    *  Converts an integer to a friendly text representation
    */
+   value = value.toString();
 
-   var firstDigit = value.slice(0);
+   var firstDigit = value.slice(0, 1);
+   var appendWith = value.slice(1);
+   if (appendWith.length === 3) {
+     var units = "thousand";
+   }
 
-  if value.
-
-
-
-  return "1 thousand";
+   return firstDigit + " " + units;
 }
 
 module.exports = intWord;

--- a/src/intWord.js
+++ b/src/intWord.js
@@ -3,6 +3,8 @@ function intWord(value) {
   /*
    *  Converts an integer to a friendly text representation
    */
+  /*jslint unparam: true*/
+  return "1";
 }
 
 module.exports = intWord;

--- a/src/intWord.js
+++ b/src/intWord.js
@@ -3,19 +3,18 @@ function intWord(value) {
   /*
    *  Converts an integer to a friendly text representation
    */
-   var units = "";
-   value = value.toString();
+  value = value.toString();
+  var units = "",
+    firstDigit = value.slice(0, 1),
+    appendWith = value.slice(1);
+  if (appendWith.length === 3) {
+    units = "thousand";
+  }
+  if (appendWith.length === 2) {
+    units = "hundred";
+  }
 
-   var firstDigit = value.slice(0, 1);
-   var appendWith = value.slice(1);
-   if (appendWith.length === 3) {
-     units = "thousand";
-   }
-   if (appendWith.length === 2) {
-     units = "hundred";
-   }
-
-   return firstDigit + " " + units;
+  return firstDigit + " " + units;
 }
 
 module.exports = intWord;

--- a/src/intWord.js
+++ b/src/intWord.js
@@ -3,12 +3,16 @@ function intWord(value) {
   /*
    *  Converts an integer to a friendly text representation
    */
+   var units = "";
    value = value.toString();
 
    var firstDigit = value.slice(0, 1);
    var appendWith = value.slice(1);
    if (appendWith.length === 3) {
-     var units = "thousand";
+     units = "thousand";
+   }
+   if (appendWith.length === 2) {
+     units = "hundred";
    }
 
    return firstDigit + " " + units;

--- a/src/intWord.js
+++ b/src/intWord.js
@@ -3,8 +3,14 @@ function intWord(value) {
   /*
    *  Converts an integer to a friendly text representation
    */
-  /*jslint unparam: true*/
-  return "1";
+
+   var firstDigit = value.slice(0);
+
+  if value.
+
+
+
+  return "1 thousand";
 }
 
 module.exports = intWord;

--- a/src/isSeven.js
+++ b/src/isSeven.js
@@ -3,6 +3,8 @@ function isSeven(value) {
   /*
    *  Returns boolean as to whether the provided value is the number 7.
    */
+  /*jslint unparam: true*/
+  return true;
 }
 
 module.exports = isSeven;

--- a/src/rollDice.js
+++ b/src/rollDice.js
@@ -3,6 +3,8 @@ function rollDice(diceSides, diceCount) {
   /*
    *  Returns an array of results from rolling dice.
    */
+  /*jslint unparam: true*/
+  return 6;
 }
 
 module.exports = rollDice;


### PR DESCRIPTION
The `intWord` feature returns a string representing the value provided. Currently verfied with two use cases - converting 1000 to "1 thousand" and converting 100 to "1 hundred". 

![](https://cloud.githubusercontent.com/assets/18199304/17153049/dc0f0e84-5337-11e6-9bf4-4a4c22daca45.jpg)
